### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 RUN mkdir /website
 WORKDIR /website
-COPY *./
-COPY *./
+COPY * ./
 EXPOSE 8000
 CMD python -m http.server 8000


### PR DESCRIPTION
You don't need two `COPY` statements - one is enough.

You need spaces between each thing you pass to `COPY`. The command should be of the form `COPY <a> <b>`, where a is the thing you're copying (your website files) and `b` is where you're copying to - in this case `./` means the current directory.